### PR TITLE
 Kafka producer

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/ProductorAcks.md
+++ b/ProductorAcks.md
@@ -1,0 +1,228 @@
+### Procutor Acks
+
+- **Productor Acks** é um mecanismo que permite que o produtor saiba se a mensagem foi entregue com sucesso ao broker.
+- O produtor pode configurar o nível de garantia de entrega de mensagens usando a propriedade `acks`.
+- Existem três valores possíveis para a propriedade `acks`:
+    - `acks=0`: O produtor não aguarda confirmação de entrega da mensagem.
+    - `acks=1`: O produtor aguarda a confirmação de entrega da mensagem pelo líder da partição.
+    - `acks=all`: O produtor aguarda a confirmação de entrega da mensagem por todos os replicas da partição.
+    - O valor padrão é `acks=1`.
+    - O valor `acks=all` fornece a garantia mais forte de que a mensagem foi entregue com sucesso, mas também tem um
+      impacto na latência de produção.
+    - O valor `acks=0` fornece a menor garantia de entrega, mas também tem o menor impacto na latência de produção.
+
+### Exemplo de Produtor com Acks
+
+```java
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+public class ProductorDemoAcks {
+    private static final Logger log = LoggerFactory.getLogger(ProductorDemoAcks.class.getName());
+
+    public static void main(String[] args) {
+        // Exemplo com acks=0
+        Properties propertiesAcks0 = getProperties("0");
+        sendMessages(propertiesAcks0);
+
+        // Exemplo com acks=1
+        Properties propertiesAcks1 = getProperties("1");
+        sendMessages(propertiesAcks1);
+
+        // Exemplo com acks=all
+        Properties propertiesAcksAll = getProperties("all");
+        sendMessages(propertiesAcksAll);
+    }
+
+    private static Properties getProperties(String acks) {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        properties.setProperty("acks", acks);
+        return properties;
+    }
+
+    private static void sendMessages(Properties properties) {
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            for (int i = 0; i < 10; i++) {
+                String topic = "acks_topic";
+                String key = "key_" + i;
+                String value = "Hello world " + i;
+                ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+                producer.send(record, (metadata, exception) -> {
+                    if (exception == null) {
+                        log.info("Sent message with key: {} to partition: {}, offset: {}", key, metadata.partition(),
+                                metadata.offset());
+                    } else {
+                        log.error("Error while sending message: {}", exception.getMessage());
+                    }
+                });
+            }
+            producer.flush();
+        }
+    }
+}
+```
+
+O código ```ProductorDemoAcks``` é um exemplo de um produtor Kafka que envia mensagens com diferentes configurações
+de ```acks```. Aqui está um resumo do que ele faz e quando usar cada configuração:
+
+### Resumo do Código
+
+- **Configuração de acks**: O código configura o produtor Kafka para usar diferentes valores de acks (0, 1, all).
+- **Envio de Mensagens**: Envia 10 mensagens para o tópico acks_topic com uma chave e um valor.
+- **Callback**: Um callback é usado para registrar o sucesso ou falha do envio de cada mensagem.
+- **Flush**: O produtor é limpo após o envio de todas as mensagens.
+
+Quando a configuração ```acks``` é igual a ```0```, o produtor Kafka não espera por nenhum reconhecimento do broker.
+Isso significa que o produtor considera a mensagem enviada assim que ela é escrita na rede, sem garantir que o broker a
+tenha recebido
+
+No log de saída, você vê que todas as mensagens são enviadas com um ```offset``` de ```-1```.
+Isso ocorre porque o produtor não espera por uma confirmação do broker, então ele não sabe o ```offset``` real da
+mensagem na partição.
+
+- **Aqui está um resumo do que cada linha do log representa**:
+    - **Sent message with key: key_0 to partition: 0, offset: -1**: A mensagem com a chave ```key_0``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_1 to partition: 0, offset: -1**: A mensagem com a chave ```key_1``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_2 to partition: 0, offset: -1**: A mensagem com a chave ```key_2``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_3 to partition: 0, offset: -1**: A mensagem com a chave ```key_3``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_4 to partition: 0, offset: -1**: A mensagem com a chave ```key_4``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_5 to partition: 0, offset: -1**: A mensagem com a chave ```key_5``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_6 to partition: 0, offset: -1**: A mensagem com a chave ```key_6``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_7 to partition: 0, offset: -1**: A mensagem com a chave ```key_7``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_8 to partition: 0, offset: -1**: A mensagem com a chave ```key_8``` foi enviada para
+      a partição ```0``` com um offset de ```-1```.
+    - **Sent message with key: key_9 to partition: 0, offset: -1**: A mensagem com a chave ```key_9``` foi enviada para
+      a partição ```
+
+- **kafka-producer-network-thread | producer-1**: Indica a thread do produtor Kafka que está enviando as mensagens.
+- **INFO code.with.vanilson.ProductorDemoAcks**: Indica que a mensagem de log vem da classe ProductorDemoAcks.
+- **Sent message with key: key_X to partition: Y, offset: -1**: Indica que a mensagem com a chave ```key_X``` foi
+  enviada para a partição ```Y```, mas o ```offse```t é ```-1``` porque o produtor não recebeu confirmação do broker.
+-
+
+Este comportamento é esperado quando ```acks``` é configurado para ```0```, pois o produtor não espera por nenhum
+reconhecimento e, portanto, não sabe o ```offset``` real das mensagens.
+
+### Exemplo com acks=1
+
+Quando a configuração ```acks``` é igual a ```1```, o produtor Kafka espera por uma confirmação do líder da partição.
+Isso significa que o produtor considera a mensagem enviada assim que o líder da partição a recebe e confirma o
+recebimento.
+
+o log de saída, você vê que todas as mensagens são enviadas com um ```offset``` específico.
+Isso ocorre porque o líder da partição reconhece a mensagem e retorna o ```offset``` real da mensagem na partição.
+
+- **Aqui está um resumo do que cada linha do log representa**:
+- **Sent message with key: key_0 to partition: 0, offset: 0**: A mensagem com a chave ```key_0``` foi enviada para a
+  partição ```0``` com um offset de ```0```.
+- **Sent message with key: key_1 to partition: 0, offset: 1**: A mensagem com a chave ```key_1``` foi enviada para a
+  partição ```0``` com um offset de ```1```.
+- **Sent message with key: key_2 to partition: 0, offset: 2**: A mensagem com a chave ```key_2``` foi enviada para a
+  partição ```0``` com um offset de ```2```.
+- **Sent message with key: key_3 to partition: 0, offset: 3**: A mensagem com a chave ```key_3``` foi enviada para a
+  partição ```0``` com um offset de ```3```.
+- **Sent message with key: key_4 to partition: 0, offset: 4**: A mensagem com a chave ```key_4``` foi enviada para a
+  partição ```0``` com um offset de ```4```.
+- **Sent message with key: key_5 to partition: 0, offset: 5**: A mensagem com a chave ```key_5``` foi enviada para a
+  partição ```0``` com um offset de ```5```.
+- **Sent message with key: key_6 to partition: 0, offset: 6**: A mensagem com a chave ```key_6``` foi enviada para a
+  partição ```0``` com um offset de ```6```.
+- **Sent message with key: key_7 to partition: 0, offset: 7**: A mensagem com a chave ```key_7``` foi enviada para a
+  partição ```0``` com um offset de ```7```.
+- **Sent message with key: key_8 to partition: 0, offset: 8**: A mensagem com a chave ```key_8``` foi enviada para a
+  partição ```0``` com um offset de ```8```.
+- **Sent message with key: key_9 to partition: 0, offset: 9**: A mensagem com a chave ```key_9``` foi enviada para a
+  partição ```0``` com um offset de ```9```.
+
+- **kafka-producer-network-thread | producer-1**: Indica a thread do produtor Kafka que envia as mensagens.
+- **INFO code.with.vanilson.ProductorDemoAcks**: Indica que a mensagem de log vem da classe ProductorDemoAcks.
+- **Sent message with key: key_X to partition: Y, offset: Z**: Indica que a mensagem com a chave ```key_X``` foi enviada
+  para a partição ```Y``` e recebeu o ```offset``` Z após ser reconhecida pelo líder da partição.
+  Este comportamento é esperado quando ```acks``` é configurado para ```1```, pois o produtor espera por um
+  reconhecimento do líder da partição, garantindo que a mensagem foi recebida e registrada no log do líder.
+
+### Exemplo com acks=all
+
+Quando a configuração ```acks``` é igual a ```all```, o produtor Kafka espera por uma confirmação de todos os replicas
+da partição.
+Isso significa que o produtor considera a mensagem enviada assim que todos os replicas da partição a recebem e confirmam
+o recebimento.
+
+No log de saída, você vê que todas as mensagens são enviadas com um ```offset``` específico.
+Isso ocorre porque todos os replicas da partição reconhecem a mensagem e retornam o ```offset``` real da mensagem na
+partição.
+
+- **Aqui está um resumo do que cada linha do log representa**:
+- **Sent message with key: key_0 to partition: 0, offset: 0**: A mensagem com a chave ```key_0``` foi enviada para a
+  partição ```0``` com um offset de ```0```.
+- **Sent message with key: key_1 to partition: 0, offset: 1**: A mensagem com a chave ```key_1``` foi enviada para a
+  partição ```0``` com um offset de ```1```.
+- **Sent message with key: key_2 to partition: 0, offset: 2**: A mensagem com a chave ```key_2``` foi enviada para a
+  partição ```0``` com um offset de ```2```.
+- **Sent message with key: key_3 to partition: 0, offset: 3**: A mensagem com a chave ```key_3``` foi enviada para a
+  partição ```0``` com um offset de ```3```.
+- **Sent message with key: key_4 to partition: 0, offset: 4**: A mensagem com a chave ```key_4``` foi enviada para a
+  partição ```0``` com um offset de ```4```.
+- **Sent message with key: key_5 to partition: 1, offset: 5**: A mensagem com a chave ```key_5``` foi enviada para a
+  partição ```1``` com um offset de ```5```.
+- **Sent message with key: key_6 to partition: 1, offset: 6**: A mensagem com a chave ```key_6``` foi enviada para a
+- **Sent message with key: key_7 to partition: 1, offset: 7**: A mensagem com a chave ```key_7``` foi enviada para a
+- **Sent message with key: key_8 to partition: 1, offset: 8**: A mensagem com a chave ```key_8``` foi enviada para a
+- **Sent message with key: key_9 to partition: 1, offset: 9**: A mensagem com a chave ```key_9``` foi enviada para a
+- **Sent message with key: key_0 to partition: 0, offset: 10**: A mensagem com a chave ```key_0``` foi enviada para a
+- **Sent message with key: key_1 to partition: 0, offset: 11**: A mensagem com a chave ```key_1``` foi enviada para a
+- **Sent message with key: key_2 to partition: 0, offset: 12**: A mensagem com a chave ```key_2``` foi enviada para a
+- **Sent message with key: key_3 to partition: 0, offset: 13**: A mensagem com a chave ```key_3``` foi enviada para a
+
+- **kafka-producer-network-thread | producer-1**: Indica a thread do produtor Kafka que envia as mensagens.
+- **INFO code.with.vanilson.ProductorDemoAcks**: Indica que a mensagem de log vem da classe ProductorDemoAcks.
+- **Sent message with key: key_X to partition: Y, offset: Z**: Indica que a mensagem com a chave ```key_X``` foi enviada
+  para a partição ```Y``` e recebeu o ```offset``` Z após ser reconhecida por todos os replicas da partição.
+  Este comportamento é esperado quando ```acks``` é configurado para ```all```, pois o produtor espera por um
+  reconhecimento de todos os replicas da partição, garantindo que a mensagem foi recebida e registrada no log de todos
+  os replicas.
+
+### Resumo
+
+- **acks=0**: O produtor não aguarda confirmação de entrega da mensagem.
+- **acks=1**: O produtor aguarda a confirmação de entrega da mensagem pelo líder da partição.
+- **acks=all**: O produtor aguarda a confirmação de entrega da mensagem por todos os replicas da partição.
+- **O valor padrão é acks=1**.
+- **O valor acks=all fornece a garantia mais forte de que a mensagem foi entregue com sucesso, mas também tem um impacto
+  na latência de produção**.
+- **O valor acks=0 fornece a menor garantia de entrega, mas também tem o menor impacto na latência de produção**.
+- **Dica**: Teste e ajuste a configuração de acks com base nos requisitos de latência e garantia de entrega do seu
+  aplicativo.
+- **Conclusão**: O mecanismo de acks do Kafka permite que os produtores ajustem a garantia de entrega de mensagens com
+  base nas necessidades do aplicativo.
+- **Use acks=0 para baixa latência e aceitação de perda de mensagens**.
+- **Use acks=1 para equilíbrio entre latência e garantia de entrega**.
+- **Use acks=all para garantia máxima de entrega, mesmo com maior latência**.
+
+
+### Conclusão
+
+O mecanismo de acks do Kafka permite que os produtores ajustem a garantia de entrega de mensagens com base nas
+necessidades do aplicativo.
+
+- Use acks=0 para baixa latência e aceitação de perda de mensagens.
+- Use acks=1 para equilíbrio entre latência e garantia de entrega.
+- Use acks=all para garantia máxima de entrega, mesmo com maior latência.

--- a/ProdutorKey.md
+++ b/ProdutorKey.md
@@ -1,0 +1,194 @@
+## Produtor com Chaves
+
+O produtor envia mensagens com chaves para garantir que mensagens com a mesma chave sejam enviadas para a mesma
+partição.
+Isso é feito usando o seguinte código:
+
+```java
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+public class ProducerDemoKeys {
+    private static final Logger log = LoggerFactory.getLogger(ProducerDemoKeys.class.getName());
+
+    public static void main(String[] args) {
+        Properties properties = getProperties();
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            for (int j = 0; j < 2; j++) {
+                for (int i = 0; i <= 10; i++) {
+                    String topic = "demo_java";
+                    String key = "truck_id " + i;
+                    String value = "Hello world " + i;
+                    ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+                    producer.send(record, (recordMetadata, e) -> {
+                        if (e == null) {
+                            log.info("key :{} | Partition:{} ", key, recordMetadata.partition());
+                        } else {
+                            log.error("Error while sending message to Kafka {} ", e.getMessage());
+                        }
+                    });
+                }
+                Thread.sleep(500);
+                producer.flush();
+            }
+        } catch (InterruptedException e) {
+            log.error("Thread exception error ", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        return properties;
+    }
+}
+```
+
+## Explicaçãa
+
+- **Configuração das Propriedades**: As propriedades do produtor são configuradas para se conectar ao broker Kafka, e os
+  serializadores de chave e valor são definidos como ```StringSerializer```.
+
+- **Envio de Mensagens**: O produtor envia 10 mensagens para o tópico ```demo_java```. Cada mensagem tem uma
+  chave (```truck_id i```) e um valor (```Hello world i```). A chave garante que mensagens com a mesma chave sejam
+  enviadas para a mesma partição.
+
+- **Callback**: Um callback é fornecido para lidar com o resultado do envio da mensagem. Se a mensagem for enviada com
+  sucesso, o log exibirá a chave e a partição para a qual a mensagem foi enviada. Se houver um erro, o log exibirá uma
+  mensagem de erro.
+
+- **Flush**: O produtor é limpo após o envio de todas as mensagens.
+
+- **Thread Sleep**: Uma pausa de 500 ms é adicionada entre os envios de mensagens para simular um intervalo de tempo
+  entre as mensagens.
+
+- **Tratamento de Exceções**: Qualquer exceção lançada durante o envio de mensagens é tratada e registrada no log.
+
+- **Log**: O log é usado para registrar mensagens de sucesso e erro durante o envio de mensagens.
+
+- **Encerramento do Produtor**: O produtor é fechado automaticamente após o bloco try-with-resources.
+
+- **Propriedades**: O método ```getProperties()``` é usado para configurar as propriedades do produtor.
+
+- **Partições**: O log exibirá a chave e a partição para a qual a mensagem foi enviada.
+
+- **Chave**: A chave é usada para garantir que mensagens com a mesma chave sejam enviadas para a mesma partição.
+
+## resumo do código
+
+O código acima é um produtor que envia mensagens com chaves para garantir que mensagens com a mesma chave sejam enviadas
+para a mesma partição.
+
+### Particionamento Round-Robin
+
+Se não especificar uma chave, o Kafka usará um particionamento round-robin para distribuir as mensagens entre as
+partições.
+Isso significa que as mensagens serão distribuídas uniformemente entre as partições disponíveis e não haverá garantia de
+que
+mensagens com a mesma chave sejam enviadas para a mesma partição. Isso pode resultar em mensagens fora de ordem se a
+ordem
+for importante para o processamento dos dados.
+
+### Resumo
+Quando a chave é nula, o Kafka usa o particionador ```Round-Robin``` para distribuir mensagens entre as partições. Isso não
+garante um balanceamento perfeito de carga, especialmente em cenários de alta concorrência. Para garantir que mensagens
+com a mesma chave sejam enviadas para a mesma partição, é necessário especificar uma chave ao enviar mensagens.
+
+## Execução
+```java
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+public class ProducerDemoKeys {
+    private static final Logger log = LoggerFactory.getLogger(ProducerDemoKeys.class.getName());
+
+    public static void main(String[] args) {
+        Properties properties = getProperties();
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            for (int j = 0; j < 2; j++) {
+                for (int i = 0; i <= 10; i++) {
+                    String topic = "demo_java";
+                    String value = "Hello world " + i;
+                    ProducerRecord<String, String> record = new ProducerRecord<>(topic, value);
+                    producer.send(record, (recordMetadata, e) -> {
+                        if (e == null) {
+                            log.info("Topic :{} | Partition:{} | Offset:{} | Timestamp :{}", 
+                                    recordMetadata.topic(),
+                                    recordMetadata.partition(),
+                                    recordMetadata.offset(),
+                                    recordMetadata.timestamp());
+                        } else {
+                            log.error("Error while sending message to Kafka {} ", e.getMessage());
+                        }
+                    });
+                }
+                Thread.sleep(500);
+                producer.flush();
+            }
+        } catch (InterruptedException e) {
+            log.error("Thread exception error ", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        return properties;
+    }
+}
+```
+### explicação
+- **Partições**: O log exibirá o tópico, a partição, o offset e o timestamp para a mensagem enviada.
+- **Chave**: Sem chave, o Kafka usará o particionador ```Round-Robin``` para distribuir mensagens entre as partições.
+- **codigo**: O código acima é um produtor que envia mensagens sem chaves, resultando em um particionamento
+  ```Round-Robin``` das mensagens entre as partições.
+- **Execução**: O código pode ser executado para enviar mensagens sem chaves para o tópico ```demo_java```.
+- **Resultado**: O log exibirá o tópico, a partição, o offset e o timestamp para cada mensagem enviada.
+- **Particionamento Round-Robin**: Sem chave, o Kafka usará um particionamento ```Round-Robin``` para distribuir as
+  mensagens entre as partições.
+- **Resumo**: Quando a chave é nula, o Kafka usa o particionador ```Round-Robin``` para distribuir mensagens entre as
+  partições. Isso não garante um balanceamento perfeito de carga, especialmente em cenários de alta concorrência.
+
+## Particionador Sticky
+O particionador ```Sticky``` é uma técnica que garante que mensagens com a mesma chave sejam enviadas para a mesma
+partição. Isso pode ser útil para garantir a ordem de mensagens relacionadas ou para agrupar mensagens com base num
+critério específico.
+Garante um melhor desempenho e eficiência no processamento de dados no Kafka, pois as mensagens relacionadas são
+agrupadas na mesma partição.
+Isto garante o balanceamento de carga e a ordem de mensagens relacionadas, o que pode ser útil para cenários em que a
+ordem é importante para o processamento dos dados.
+
+### Resumo
+O particionador ```Sticky``` é uma técnica que garante que mensagens com a mesma chave sejam enviadas para a mesma
+partição. Isso pode ser útil para garantir a ordem de mensagens relacionadas ou para agrupar mensagens com base num
+critério específico. Ao especificar uma chave ao enviar mensagens, é possível controlar como as mensagens são
+distribuídas entre as partições e garantir um processamento eficiente dos dados no Kafka.
+
+
+
+
+## Conclusão
+O particionamento de chaves é uma técnica importante para garantir que mensagens com a mesma chave sejam enviadas para a
+mesma partição. Isso pode ser útil para garantir a ordem de mensagens relacionadas ou para agrupar mensagens com base em
+um critério específico. Ao especificar uma chave ao enviar mensagens, é possível controlar como as mensagens são
+distribuídas entre as partições e garantir um processamento eficiente dos dados no Kafka.

--- a/kafka-basic/src/main/java/code/with/vanilson/ProducerDemoKeys.java
+++ b/kafka-basic/src/main/java/code/with/vanilson/ProducerDemoKeys.java
@@ -1,0 +1,64 @@
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * ProducerDemoKeys
+ *
+ * @author vamuhong
+ * @version 1.0
+ * @since 2025-02-18
+ */
+public class ProducerDemoKeys {
+    private static final Logger log = LoggerFactory.getLogger(ProducerDemoKeys.class.getName());
+
+    public static void main(String[] args) {
+        Properties properties = getProperties();
+        // Criar uma mensagem para enviar para o tópico Kafka. A mensagem é composta por um valor e uma chave.
+        // A chave é usada para garantir que a mensagem com a mesma chave seja enviada para a mesma partição.
+        // Se a chave for nula, o Kafka escolherá aleatoriamente uma partição para enviar a mensagem.
+        // Se a chave não for nula, o Kafka garantirá que todas as mensagens com a mesma chave sejam enviadas para a mesma partição.
+        // Para melhorar o desempenho, o produtor usa o que é chamado de sticky partitioning, onde várias mensagens são enviadas para a mesma partição até que um certo limite seja atingido, antes de mudar para outra partição.
+        // O particionador Round-Robin é usado para distribuir as mensagens de forma equilibrada entre todas as partições disponíveis.
+        // O particionador Round-Robin é o particionador padrão do Kafka.
+        // O particionador Round-Robin é usado quando a chave é nula.
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            // Enviar 10 mensagens para o tópico Kafka chamado "demo_java". Isto é que chamamos sticky partitioning,
+            // onde a mesma chave é enviada para a mesma partição.
+            for (int j = 0; j < 2; j++) {
+                for (int i = 0; i <= 10; i++) {
+                    String topic = "demo_java";
+                    String key = "truck_id " + i;
+                    String value = "Hello world " + i;
+                    ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+                    producer.send(record, (recordMetadata, e) -> {
+                        if (e == null) {
+                            log.info("key :{}", key + "| Partition:{} " + recordMetadata.partition());
+                        } else {
+                            log.error("Error while sending message to Kafka {} ", e.getMessage());
+                        }
+                    });
+                }
+                Thread.sleep(500);
+                producer.flush();
+            }
+        } catch (InterruptedException e) {
+            log.error("Thread exception error ", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        return properties;
+    }
+}

--- a/kafka-basic/src/main/java/code/with/vanilson/ProducerDemoWithCallback.java
+++ b/kafka-basic/src/main/java/code/with/vanilson/ProducerDemoWithCallback.java
@@ -1,0 +1,126 @@
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RoundRobinPartitioner;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * ProducerDemoWithCallback
+ *
+ * @author vamuhong
+ * @version 1.0
+ * @since 2025-02-18
+ */
+public class ProducerDemoWithCallback {
+
+    private static final Logger log = LoggerFactory.getLogger(ProducerDemoWithCallback.class.getName());
+
+    public static void main(String[] args) {
+
+        // Criar propriedades do produtor Kafka (Producer)
+        Properties properties = getProperty();
+
+        // Enviar 10 mensagens para o tópico Kafka chamado "prod_topic" e "prod_topic_1". Isto é que chamamos
+        // sticky pArtitioning, onde a mesma chave é enviada para a mesma partição.
+        for (int i = 0; i < 10; i++) {
+
+            // Criar um produtor Kafka (Producer) com as propriedades configuradas acima (properties) e a chave e valor do tipo ‘String’.
+            try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+                // Enviar uma mensagem para o tópico Kafka chamado "demo_java". Mas tem que ser criado antes no terminal o topic com o comando: kafka-topics --create --topic demo_java --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+                // Criar um objeto ProducerRecord com o tópico Kafka, chave e valor. Quando usamos a chave, o Kafka garante que a mensagem com a mesma chave será enviada para a mesma partição. Se a chave for nula, o Kafka escolherá aleatoriamente uma partição para enviar a mensagem.
+                ProducerRecord<String, String> record =
+                        new ProducerRecord<>("twitter", "Hello twitter !! " + i);
+                ProducerRecord<String, String> record2 =
+                        new ProducerRecord<>("udemy", "Hello Udemy !!" + i);
+                // Enviar a mensagem para o tópico Kafka.
+                sendMessageToKafkaTopic(producer, record);
+                sendMessageToKafkaTopic(producer, record2);
+                // Diz ao produtor para enviar todas as mensagens pendentes para o tópico Kafka até o momento - sincrónico (bloqueante).
+                producer.flush();
+            } catch (ClassCastException e) {
+                log.error("Error while sending message to Kafka {}", e.getMessage());
+            }
+        }
+    }
+    // Mensagens produzidas pelo produtor podem ter um valor nulo, mas não podem ter uma chave nula.
+// Se a chave for nula, o Kafka escolherá aleatoriamente uma partição para enviar a mensagem usando o particionador Round-Robin.
+// Ou seja, a mensagem será distribuída de forma equilibrada entre todas as partições disponíveis.
+// Se a chave não for nula, o Kafka garantirá que todas as mensagens com a mesma chave serão enviadas para a mesma partição.
+// Para melhorar o desempenho, o produtor usa o que é chamado de sticky partitioning, onde várias mensagens são enviadas para a mesma partição até que um certo limite seja atingido, antes de mudar para outra partição.
+
+    /**
+     * Método para enviar a mensagem para o tópico Kafka.
+     * Se a exceção for nula, a mensagem foi enviada com sucesso.
+     * Se a mensagem foi enviada com sucesso, o Kafka retornará os metadados da mensagem.
+     * Se a exceção não for nula, um erro ocorreu ao enviar a mensagem para o tópico Kafka.
+     *
+     * @param producer - produtor Kafka (Producer).
+     * @param record   - objeto ProducerRecord com o tópico Kafka, chave e valor.
+     */
+    private static void sendMessageToKafkaTopic(KafkaProducer<String, String> producer,
+                                                ProducerRecord<String, String> record) {
+        producer.send(record, (metadata, exception) -> {
+            // Se a exceção for nula, a mensagem foi enviada com sucesso.
+            if (exception == null) {
+                // Se a mensagem foi enviada com sucesso, o Kafka retornará os metadados da mensagem.
+                log.info("Recebendo novos metadados: \nTopic: {}\nPartition: {}\nOffset: {}\nTimestamp: {}",
+                        metadata.topic(), metadata.partition(), metadata.offset(), metadata.timestamp());
+            } else {
+                log.error("Error while producing message to Kafka: {}", exception.getMessage());
+            }
+        });
+    }
+
+    /**
+     * Método para configurar as propriedades do produtor Kafka (Producer) - bootstrap.servers é o endereço do servidor Kafka
+     * (Broker) que o produtor deve se conectar para enviar mensagens.
+     * key.serializer é a classe de serialização da chave que será enviada para o tópico Kafka.
+     * value.serializer é a classe de serialização do valor que será enviado para o tópico Kafka.
+     *
+     * @return Properties - propriedades do produtor Kafka (Producer).
+     * @see Properties - propriedades do produtor Kafka (Producer).
+     * @since 2025-02-18
+     */
+
+    private static Properties getProperty() {
+        Properties properties = new Properties();
+        // Configurar propriedades do produtor Kafka (Producer) - bootstrap.servers é o endereço do servidor Kafka
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        // Configurar propriedades do produtor Kafka (Producer) - acks é a confirmação que o líder da partição do
+        // tópico Kafka enviou a mensagem com sucesso. O valor "all" é a configuração mais segura, pois garante que
+        // a mensagem foi recebida com sucesso por todos os seguidores e líder da partição.
+        // acks=0 - não há confirmação, a mensagem é enviada e esquecida.
+        // acks=1 - confirmação do líder da partição.
+        // acks=all - confirmação do líder da partição e todos os seguidores.
+        // Mesmo que acks -1, o líder da partição envia uma confirmação de que a mensagem foi recebida com sucesso.
+        properties.setProperty("acks", "all");
+
+       // Configurar propriedades do produtor Kafka (Producer) - partitioner.class é a classe de particionador que
+        // será usada para distribuir as mensagens entre as partições do tópico Kafka.
+       properties.setProperty("partitioner.class", RoundRobinPartitioner.class.getName());
+
+        // Configurar propriedades do produtor Kafka (Producer) - retries é o número de tentativas que o produtor
+        // Kafka fará ao enviar mensagens para o tópico Kafka.
+        properties.setProperty("retries", "3");
+        // Configurar propriedades do produtor Kafka (Producer) - linger.ms é o tempo em milissegundos que o produtor
+        // Kafka aguardará antes de enviar mensagens para o tópico Kafka.
+        properties.setProperty("linger.ms", "1");
+        // Configurar propriedades do produtor Kafka (Producer) - buffer.memory é o tamanho do buffer de memória que o
+        // produtor Kafka usará para armazenar mensagens antes de enviá-las para o tópico Kafka.
+        properties.setProperty("buffer.memory", "33554432");
+        // Configurar propriedades do produtor Kafka (Producer) - batch.size é o tamanho do lote que o produtor Kafka
+        // usará para enviar mensagens para o tópico Kafka.
+        properties.setProperty("batch.size", "400");
+
+        // Configurar propriedades do produtor Kafka (Producer) - key.serializer é a classe de serialização da chave que será enviada para o tópico Kafka.
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        // Configurar propriedades do produtor Kafka (Producer) - value.serializer é a classe de serialização do valor que será enviado para o tópico Kafka.
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        return properties;
+    }
+}

--- a/kafka-basic/src/main/java/code/with/vanilson/ProductorDemoAcks.java
+++ b/kafka-basic/src/main/java/code/with/vanilson/ProductorDemoAcks.java
@@ -1,0 +1,63 @@
+package code.with.vanilson;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * ProductorDemoAcks
+ *
+ * @author vamuhong
+ * @version 1.0
+ * @since 2025-02-18
+ */
+public class ProductorDemoAcks {
+    private static final Logger log = LoggerFactory.getLogger(ProductorDemoAcks.class.getName());
+
+    public static void main(String[] args) {
+        // Exemplo com acks=0
+        Properties propertiesAcks0 = getProperties("0");
+        sendMessages(propertiesAcks0);
+
+        // Exemplo com acks=1
+        Properties propertiesAcks1 = getProperties("1");
+        sendMessages(propertiesAcks1);
+
+        // Exemplo com acks=all
+        Properties propertiesAcksAll = getProperties("all");
+        sendMessages(propertiesAcksAll);
+    }
+
+    private static Properties getProperties(String acks) {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+        properties.setProperty("key.serializer", StringSerializer.class.getName());
+        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        properties.setProperty("acks", acks);
+        return properties;
+    }
+
+    private static void sendMessages(Properties properties) {
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            for (int i = 0; i < 10; i++) {
+                String topic = "acks_topic";
+                String key = "key_" + i;
+                String value = "Hello world!! knowlegde is power " + i;
+                ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+                producer.send(record, (metadata, exception) -> {
+                    if (exception == null) {
+                        log.info("Sent message with key: {} to partition: {}, offset: {}", key, metadata.partition(),
+                                metadata.offset());
+                    } else {
+                        log.error("Error while sending message: {}", exception.getMessage());
+                    }
+                });
+            }
+            producer.flush();
+        }
+    }
+}


### PR DESCRIPTION
feat: Add Kafka producer example with different acks configurations

- Implement `ProductorDemoAcks` class to demonstrate Kafka producer with `acks` configurations (`0`, `1`, `all`).
- Add detailed explanations and examples for each `acks` configuration in `ProductorAcks.md`.
- Provide logging for message sending with key, partition, and offset information.
- Include troubleshooting steps for Kafka broker leader issues.

This commit provides a comprehensive example and documentation for using Kafka producer with different `acks` settings, helping to understand the trade-offs between latency and message delivery guarantees.