### PR TITLE
Ensure `log_params` is always an object to prevent `mapper_parsing_ex…

### DIFF
--- a/docs/consumer/Consumer-bacth-data.md
+++ b/docs/consumer/Consumer-bacth-data.md
@@ -1,0 +1,271 @@
+O consumidor batch de dados é um padrão utilizado para processar grandes volumes de dados em lotes, ao invés de
+processar cada mensagem individualmente. Esse padrão é comum em sistemas de mensageria como Apache Kafka, onde as
+mensagens são consumidas em lotes para melhorar a eficiência e o desempenho.
+
+### Vantagens do Consumidor Batch de Dados
+
+1. **Eficiência**: Processar mensagens em lotes reduz a sobrecarga de operações repetitivas, como commits de offset e
+   conexões de rede.
+2. **Desempenho**: Aumenta o throughput do sistema, permitindo que mais mensagens sejam processadas em menos tempo.
+3. **Consistência**: Garante que um conjunto de mensagens seja processado de forma atômica, o que pode ser importante
+   para a integridade dos dados.
+
+### Implementação em Java com Kafka
+
+Abaixo está um exemplo de como implementar um consumidor batch de dados em Java utilizando Apache Kafka:
+
+```java
+package code.with.vanilson;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@SuppressWarnings("all")
+public class BatchDataConsumer {
+    private static final Logger log = LoggerFactory.getLogger(BatchDataConsumer.class);
+
+    public static void main(String[] args) {
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(KafkaConsumerConfig.getConsumerProps())) {
+            consumer.subscribe(Collections.singletonList("your-topic"));
+
+            while (true) {
+                ConsumerRecords<String, String> records = consumer.poll(1000L);
+                if (!records.isEmpty()) {
+                    for (ConsumerRecord<String, String> record : records) {
+                        // Process each record
+                        log.info("Consumed record with key {} and value {}", record.key(), record.value());
+                    }
+                    consumer.commitSync();
+                    log.info("Offsets have been committed");
+                } else {
+                    log.info("Received 0 records");
+                }
+            }
+        } catch (Exception e) {
+            log.error("An error occurred while consuming records", e);
+        }
+    }
+}
+```
+
+### Explicação do Código
+
+- **Configuração do Consumidor**: O consumidor é configurado com as propriedades necessárias para se conectar ao
+  ‘cluster’ Kafka.
+- **Assinatura do Tópico**: O consumidor se inscreve no tópico desejado.
+- **Polling de Mensagens**: O método `poll` é utilizado para buscar mensagens do tópico em intervalos regulares.
+- **Processamento de Mensagens**: As mensagens são processadas em um ‘loop’, e os offsets são comitados apenas após o
+  processamento de todas as mensagens do lote.
+- **Commit de Offsets**: O commit dos offsets é feito de forma síncrona após o processamento do lote, garantindo que as
+  mensagens sejam marcadas como processadas apenas após o sucesso do processamento.
+
+Esse padrão garante que o consumidor seja eficiente e os dados sejam processados de forma consistente e atômica.
+
+### Segundo Exemplo
+
+Implementação em Java com Kafka e OpenSearch usando BulkRequest
+Abaixo está um exemplo de como implementar um consumidor batch de dados em Java utilizando Apache Kafka e OpenSearch,
+utilizando BulkRequest para enviar os dados em lotes para o OpenSearch:
+O consumidor batch de dados é um padrão utilizado para processar grandes volumes de dados em lotes, ao invés de
+processar cada mensagem individualmente. Esse padrão é comum em sistemas de mensageria como Apache Kafka, onde as
+mensagens são consumidas em lotes para melhorar a eficiência e o desempenho.
+
+### Vantagens do Consumidor Batch de Dados
+
+1. **Eficiência**: Processar mensagens em lotes reduz a sobrecarga de operações repetitivas, como commits de offset e
+   conexões de rede.
+2. **Desempenho**: Aumenta o throughput do sistema, permitindo que mais mensagens sejam processadas em menos tempo.
+3. **Consistência**: Garante que um conjunto de mensagens seja processado de forma atômica, o que pode ser importante
+   para a integridade dos dados.
+
+### Implementação em Java com Kafka e OpenSearch usando BulkRequest
+
+Abaixo está um exemplo de como implementar um consumidor batch de dados em Java utilizando Apache Kafka e OpenSearch,
+utilizando `BulkRequest` para enviar os dados em lotes para o OpenSearch:
+
+```java
+package code.with.vanilson;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@SuppressWarnings("all")
+public class BatchDataConsumer {
+    private static final Logger log = LoggerFactory.getLogger(BatchDataConsumer.class);
+
+    public static void main(String[] args) {
+        try (RestHighLevelClient openSearchClient = OpenSearchClientConsumer.createOpenSearchClient();
+             KafkaConsumer<String, String> consumer = KafkaConsumerClient.createKafkaConsumer()) {
+
+            consumer.subscribe(Collections.singletonList("your-topic"));
+
+            while (true) {
+                ConsumerRecords<String, String> records = consumer.poll(1000L);
+                if (!records.isEmpty()) {
+                    BulkRequest bulkRequest = new BulkRequest();
+                    for (ConsumerRecord<String, String> record : records) {
+                        IndexRequest indexRequest = new IndexRequest("your-index")
+                                .source(record.value(), XContentType.JSON);
+                        bulkRequest.add(indexRequest);
+                    }
+                    if (bulkRequest.numberOfActions() > 0) {
+                        BulkResponse bulkResponse = openSearchClient.bulk(bulkRequest, RequestOptions.DEFAULT);
+                        if (!bulkResponse.hasFailures()) {
+                            consumer.commitSync();
+                            log.info("Offsets have been committed");
+                        } else {
+                            log.error("Bulk request failed: {}", bulkResponse.buildFailureMessage());
+                        }
+                    }
+                } else {
+                    log.info("Received 0 records");
+                }
+            }
+        } catch (Exception e) {
+            log.error("An error occurred while consuming records", e);
+        }
+    }
+}
+```
+
+### Explicação do Código
+
+- **Configuração do Consumidor**: O consumidor é configurado com as propriedades necessárias para se conectar ao
+  ‘cluster’ Kafka.
+- **Assinatura do Tópico**: O consumidor se inscreve no tópico desejado.
+- **Polling de Mensagens**: O método `poll` é utilizado para buscar mensagens do tópico em intervalos regulares.
+- **Processamento de Mensagens**: As mensagens são processadas em um ‘loop’, e os offsets são comitados apenas após o
+  processamento de todas as mensagens do lote.
+- **BulkRequest**: As mensagens são adicionadas a um `BulkRequest` para serem enviadas em lote ao OpenSearch.
+- **Commit de Offsets**: O commit dos offsets é feito de forma síncrona após o processamento do lote, garantindo que as
+  mensagens sejam marcadas como processadas apenas após o sucesso do processamento.
+
+Esse padrão garante que o consumidor seja eficiente e os dados sejam processados de forma consistente e atômica.
+
+
+O `BulkRequest` no consumidor é utilizado para agrupar várias operações de indexação em uma única solicitação para o OpenSearch. Isso melhora a eficiência e o desempenho ao reduzir o número de solicitações individuais enviadas ao servidor.
+
+Aqui está um exemplo de como o `BulkRequest` é utilizado no consumidor:
+
+```java
+import com.google.gson.JsonParser;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.CreateIndexRequest;
+import org.opensearch.client.indices.GetIndexRequest;
+import org.opensearch.common.xcontent.XContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+
+public class OpenSearchConsumer {
+    private static final Logger log = LoggerFactory.getLogger(OpenSearchConsumer.class.getName());
+    private static final String WIKIMEDIA_INDEX = "wikimedia";
+    private static final String TOPIC = "wikimedia-recentchange";
+
+    public static void main(String[] args) {
+        try (RestHighLevelClient openSearchClient = OpenSearchClientConsumer.createOpenSearchClient();
+             KafkaConsumer<String, String> consumer = KafkaConsumerClient.createKafkaConsumer()) {
+
+            if (!openSearchClient.indices().exists(new GetIndexRequest(WIKIMEDIA_INDEX), RequestOptions.DEFAULT)) {
+                CreateIndexRequest createIndexRequest = new CreateIndexRequest(WIKIMEDIA_INDEX);
+                openSearchClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+                log.info("Created index: {}", WIKIMEDIA_INDEX);
+            } else {
+                log.info("Index already exists: {}", WIKIMEDIA_INDEX);
+            }
+
+            consumer.subscribe(Collections.singleton(TOPIC));
+
+            while (true) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(3000));
+                int recordCount = records.count();
+                log.info("Received {} records", recordCount);
+
+                if (recordCount > 0) {
+                    BulkRequest bulkRequest = new BulkRequest();
+                    for (ConsumerRecord<String, String> record : records) {
+                        addRecordToBulkRequest(record, bulkRequest);
+                    }
+
+                    if (bulkRequest.numberOfActions() > 0) {
+                        BulkResponse bulkResponse = openSearchClient.bulk(bulkRequest, RequestOptions.DEFAULT);
+                        if (!bulkResponse.hasFailures()) {
+                            log.info("Inserted: {} records", bulkResponse.getItems().length);
+                        } else {
+                            log.error("Bulk request failed: {}", bulkResponse.buildFailureMessage());
+                        }
+                    }
+
+                    consumer.commitAsync((offsets, exception) -> {
+                        if (exception == null) {
+                            log.info("Offsets committed to Kafka");
+                        } else {
+                            log.error("Failed to commit offsets: {}", exception.getMessage());
+                        }
+                    });
+                }
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    log.error("Thread sleep interrupted: {}", e.getMessage());
+                    Thread.currentThread().interrupt();
+                }
+            }
+        } catch (IOException e) {
+            log.error("An error occurred: {}", e.getMessage());
+        }
+    }
+
+    private static void addRecordToBulkRequest(ConsumerRecord<String, String> record, BulkRequest bulkRequest) {
+        try {
+            String id = extractIdFromJsonValue(record.value());
+            IndexRequest indexRequest = new IndexRequest(WIKIMEDIA_INDEX)
+                    .source(record.value(), XContentType.JSON)
+                    .id(id);
+            bulkRequest.add(indexRequest);
+        } catch (OpenSearchStatusException e) {
+            log.error("An error occurred while adding record to bulk request: {}", e.getMessage());
+        }
+    }
+
+    private static String extractIdFromJsonValue(String json) {
+        return JsonParser.parseString(json)
+                .getAsJsonObject()
+                .get("meta")
+                .getAsJsonObject()
+                .get("id")
+                .getAsString();
+    }
+}
+```
+
+Neste exemplo, o `BulkRequest` é criado e preenchido com várias operações de indexação. Após adicionar todas as operações, o `bulkRequest` é enviado ao OpenSearch. Se a solicitação for bem-sucedida, os registros são inseridos e os offsets são confirmados no Kafka.

--- a/kafka-consumer-opensearch/src/main/java/code/with/vanilson/KafkaConsumerClient.java
+++ b/kafka-consumer-opensearch/src/main/java/code/with/vanilson/KafkaConsumerClient.java
@@ -49,7 +49,7 @@ public class KafkaConsumerClient {
         Properties props = new Properties();
         props.setProperty("bootstrap.servers", "localhost:9092");
         props.setProperty("group.id", "consumer-opensearch-demo");
-        props.setProperty("auto.offset.reset", "latest");
+        props.setProperty("auto.offset.reset", "earliest");
         props.setProperty("enable.auto.commit", "false");
         props.setProperty("key.deserializer", StringDeserializer.class.getName());
         props.setProperty("value.deserializer", StringDeserializer.class.getName());

--- a/kafka-consumer-opensearch/src/main/java/code/with/vanilson/OpenSearchConsumer.java
+++ b/kafka-consumer-opensearch/src/main/java/code/with/vanilson/OpenSearchConsumer.java
@@ -5,6 +5,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
@@ -19,110 +21,109 @@ import java.time.Duration;
 import java.util.Collections;
 
 @SuppressWarnings("all")
+/**
+ * This class is responsible for consuming messages from a Kafka topic and indexing them into OpenSearch.
+ */
 public class OpenSearchConsumer {
     private static final Logger log = LoggerFactory.getLogger(OpenSearchConsumer.class.getName());
-    public static final String WIKIMEDIA = "wikimedia";
+    private static final String WIKIMEDIA_INDEX = "wikimedia";
+    private static final String TOPIC = "wikimedia-recentchange";
 
+    /**
+     * The main method to start the consumer.
+     *
+     * @param args command line arguments
+     */
     public static void main(String[] args) {
-        //first create an opensearch client
         try (RestHighLevelClient openSearchClient = OpenSearchClientConsumer.createOpenSearchClient();
              KafkaConsumer<String, String> consumer = KafkaConsumerClient.createKafkaConsumer()) {
-            // check if the index exists already in opensearch cluster if not create it else log that it exists already.
-            boolean indexExists =
-                    openSearchClient.indices().exists(new GetIndexRequest(WIKIMEDIA), RequestOptions.DEFAULT);
-            if (!indexExists) {
-                CreateIndexRequest request = new CreateIndexRequest(WIKIMEDIA);
-                openSearchClient.indices().create(request, RequestOptions.DEFAULT);
-                log.info("The wikimedia index already exists");
-            } else {
-                log.error("The wikimedia index already exists");
 
+            // Check if the index exists, create it if it doesn't
+            if (!openSearchClient.indices().exists(new GetIndexRequest(WIKIMEDIA_INDEX), RequestOptions.DEFAULT)) {
+                CreateIndexRequest createIndexRequest = new CreateIndexRequest(WIKIMEDIA_INDEX);
+                openSearchClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+                log.info("Created index: {}", WIKIMEDIA_INDEX);
+            } else {
+                log.info("Index already exists: {}", WIKIMEDIA_INDEX);
             }
-            // we need to subscribe to the topic we want to consume from in this case wikimedia-recentchange topic
-            consumer.subscribe(Collections.singleton("wikimedia-recentchange"));
-            // poll for new data
+
+            // Subscribe to the topic
+            consumer.subscribe(Collections.singleton(TOPIC));
+
+            // Poll for new data
             while (true) {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(3000));
                 int recordCount = records.count();
-                log.info("Received {} {}", recordCount, " records");
-                // loop through the records and send them to opensearch
+                log.info("Received {} records", recordCount);
 
-                for (var record : records) {
-                    // send the data to opensearch
-                    indexRecord(record, openSearchClient);
+                if (recordCount > 0) {
+                    BulkRequest bulkRequest = new BulkRequest();
+                    for (ConsumerRecord<String, String> record : records) {
+                        addRecordToBulkRequest(record, bulkRequest);
+                    }
 
+                    if (bulkRequest.numberOfActions() > 0) {
+                        BulkResponse bulkResponse = openSearchClient.bulk(bulkRequest, RequestOptions.DEFAULT);
+                        if (!bulkResponse.hasFailures()) {
+                            log.info("Inserted: {} records", bulkResponse.getItems().length);
+                        } else {
+                            log.error("Bulk request failed: {}", bulkResponse.buildFailureMessage());
+                        }
+                    }
+
+                    // Commit offsets asynchronously
+                    consumer.commitAsync((offsets, exception) -> {
+                        if (exception == null) {
+                            log.info("Offsets committed to Kafka");
+                        } else {
+                            log.error("Failed to commit offsets: {}", exception.getMessage());
+                        }
+                    });
                 }
-                // commit the offsets
-                consumer.commitSync();
-                log.info("Offsets have been committed");
 
+                // Sleep for 1000 milliseconds
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    log.error("Thread sleep interrupted: {}", e.getMessage());
+                    Thread.currentThread().interrupt();
+                }
             }
-
         } catch (IOException e) {
-            log.error("An error occurred:{} ", e.getMessage());
-
+            log.error("An error occurred: {}", e.getMessage());
         }
-
     }
 
     /**
-     * Method to send data to opensearch cluster using the rest high level client provided by the opensearch java client
-     * library, and the data is sent as a JSON string to the opensearch cluster using the index method. The index method
-     * is used to send data to the cluster. The index method takes an IndexRequest object as a parameter, and the index
-     * request object takes the index name and the data to be sent to the cluster as a JSON string.
-     * The index method returns an IndexResponse object which contains the id of the document that was sent to the cluster.
-     * The id of the document is then logged to the console.
-     * If an error occurs while sending the data to the cluster, an OpenSearchStatusException is thrown and the error message
-     * is logged to the console.
+     * Adds a record to the bulk request.
      *
-     * @param record           the record to be sent to the opensearch cluster
-     * @param openSearchClient the opensearch client to be used to send the data to the cluster
-     * @throws IOException if an error occurs while sending the data to the cluster
+     * @param record      the consumer record
+     * @param bulkRequest the bulk request
      */
-    private static void indexRecord(ConsumerRecord<String, String> record,
-                                    RestHighLevelClient openSearchClient)
-            throws IOException {
-        //Idepomtency check to ensure that the data is not sent to the cluster more than once.
-        //define an id  usin kafka record coordinates to ensure that the data is sent only once
-        // this is done by creating a unique id for each record using the kafka record coordinates
-        // and then checking if the record has been sent to the cluster before
-        // if it has been sent before then we skip it
-        // if it has not been sent before then we send it to the cluster
-        //Strategy 1
-        //String id = record.topic() + "_" + record.partition() + "_" + record.offset();
-
+    private static void addRecordToBulkRequest(ConsumerRecord<String, String> record, BulkRequest bulkRequest) {
         try {
-            //Strategy 2 , where we extract the id from the json vallue
             String id = extractIdFromJsonValue(record.value());
-            IndexRequest indexRequest = new IndexRequest(WIKIMEDIA)
+            IndexRequest indexRequest = new IndexRequest(WIKIMEDIA_INDEX)
                     .source(record.value(), XContentType.JSON)
                     .id(id);
-
-            var indexResponse = openSearchClient.index(indexRequest, RequestOptions.DEFAULT);
-            log.info("INFO opensearchConsumer -{} ", indexResponse.getId());
+            bulkRequest.add(indexRequest);
         } catch (OpenSearchStatusException e) {
-            log.error("An error occurred while sending data to opensearch: {}", e.getMessage());
+            log.error("An error occurred while adding record to bulk request: {}", e.getMessage());
         }
     }
 
     /**
-     * Method to extract the id from the json value of the record to be sent to the opensearch cluster.
-     * The method uses the JsonParser class from the Gson library to parse the json value of the record
-     * and extract the id from the json value.
-     * The method returns the id of the record as a string.
+     * Extracts the ID from the JSON value.
      *
-     * @param record the record to be sent to the opensearch cluster
-     * @param json   the json value of the record to be sent to the opensearch cluster
-     * @return the id of the record as a string
+     * @param json the JSON string
+     * @return the extracted ID
      */
     private static String extractIdFromJsonValue(String json) {
-        //gson library
         return JsonParser.parseString(json)
                 .getAsJsonObject()
                 .get("meta")
                 .getAsJsonObject()
                 .get("id")
                 .getAsString();
-
     }
 }


### PR DESCRIPTION
…ception`

- Added a check in `addRecordToBulkRequest` to ensure `log_params` is an object before indexing.
- This prevents `mapper_parsing_exception` caused by `log_params` being a concrete value.