### PR TITLE
Add method to serialize log_params field and handle bulk requests

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,6 +4,13 @@
     <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,com.launchdarkly.eventsource.EventSource.Builder,build,code.with.vanilson.OpenSearchClientConsumer,createOpenSearchClient" />
     </inspection_tool>
+    <inspection_tool class="PackageUpdate" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="excludeList">
+        <list>
+          <option value="maven:com.google.code.gson:gson" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="VulnerableLibrariesLocal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="isIgnoringEnabled" value="true" />
       <option name="ignoredModules">

--- a/docs/consumer/Consumer-Strategy-Offset-Commit.md
+++ b/docs/consumer/Consumer-Strategy-Offset-Commit.md
@@ -49,3 +49,25 @@ public static void main(String[] args) {
 
 Neste exemplo, o consumidor faz o commit dos offsets manualmente após processar cada lote de mensagens, garantindo que
 os offsets reflitam com precisão o ponto de processamento.
+
+## if we commit offsets before processing the data, we are in the scenario
+
+- we are in the scenario at most once delivery semantics
+
+## if we commit offsets after processing the data, we are in the scenario
+
+- we are in the scenario at least once delivery semantics
+
+## if we commit offsets exactly once, we are in the scenario
+
+- we are in the scenario exactly once delivery semantics
+
+### if we don't want to have duplicates in our target database
+we need to make sure the processing of the data is idempotent
+
+### what's a generic unique id that I can use for messages I receive from a consumer?
+Topic + Partition + Offset
+
+## if I want to replay data for a consumer, I should?
+- reset the offsets of the current consumer used group id to the beginning of the topic.
+- set the auto.offset.reset to earliest

--- a/docs/consumer/Consumer-replay-data.md
+++ b/docs/consumer/Consumer-replay-data.md
@@ -1,0 +1,121 @@
+O "consumer replay" de dados no Kafka permite que você reprocessar mensagens a partir de um determinado ponto no log.
+Isso pode ser útil para corrigir erros ou reprocessar dados com lógica atualizada.
+
+Aqui está um exemplo básico de como configurar um consumidor Kafka para reprocessar dados a partir de um offset
+específico:
+
+1. **Configurar o consumidor para ler a partir do início do log**:
+   ```java
+   import org.apache.kafka.clients.consumer.ConsumerConfig;
+   import org.apache.kafka.clients.consumer.ConsumerRecord;
+   import org.apache.kafka.clients.consumer.ConsumerRecords;
+   import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+   import java.time.Duration;
+   import java.util.Collections;
+   import java.util.Properties;
+     @SuppressWarnings("all")
+   public class KafkaConsumerReplay {
+
+       public static void main(String[] args) {
+           Properties props = new Properties();
+           props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+           props.put(ConsumerConfig.GROUP_ID_CONFIG, "your-group-id");
+           props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+           props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+           props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // Ler do início do log
+
+           KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+           consumer.subscribe(Collections.singletonList("your-topic"));
+
+           while (true) {
+               ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
+               for (ConsumerRecord<String, String> record : records) {
+                   System.out.printf("Offset: %d, Key: %s, Value: %s%n", record.offset(), record.key(), record.value());
+                   // Processar a mensagem
+               }
+           }
+       }
+   }
+   ```
+
+2. **Configurar o consumidor para lançar uma exceção se não houver mensagens**:
+   ```java
+
+   import org.apache.kafka.clients.consumer.ConsumerConfig;
+   import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+   import java.util.Properties;
+   @SuppressWarnings("all")
+   public class KafkaConsumerConfig {
+
+       public static Properties getConsumerProps(String offsetReset) {
+           Properties props = new Properties();
+           props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+           props.put(ConsumerConfig.GROUP_ID_CONFIG, "your-group-id");
+           props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+           props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+           props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset); // earliest, latest, ou none
+           return props;
+       }
+
+       public static void main(String[] args) {
+           Properties noneProps = getConsumerProps("none");
+
+           try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(noneProps)) {
+               // Use o consumidor conforme necessário
+           } catch (Exception e) {
+               e.printStackTrace();
+           }
+       }
+   }
+   ```
+
+Neste exemplo, o consumidor é configurado para ler a partir do início do log (`earliest`) ou lançar uma exceção se não
+houver mensagens (`none`). Isso permite reprocessar mensagens ou lidar com a ausência de mensagens conforme necessário.
+
+## Configurando o Comportamento do Consumidor em Relação aos Offsets
+
+Para configurar o comportamento do consumidor Kafka relativamente aos offsets, você pode usar a
+propriedade `auto.offset.reset`. Aqui está como configurar cada um dos comportamentos mencionados:
+
+1. **`earliest`**: O consumidor lê do início do log.
+2. **`latest`**: O consumidor lê do fim do log.
+3. **`none`**: Lança uma exceção se não houver mensagens.
+
+Aqui está um exemplo de como configurar essas propriedades no consumidor Kafka:
+
+```java
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import java.util.Properties;
+
+public class KafkaConsumerConfig {
+
+    public static Properties getConsumerProps(String offsetReset) {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "your-group-id");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset); // earliest, latest, or none
+        return props;
+    }
+
+    public static void main(String[] args) {
+        // Example usage
+        Properties earliestProps = getConsumerProps("earliest");
+        Properties latestProps = getConsumerProps("latest");
+        Properties noneProps = getConsumerProps("none");
+
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(earliestProps);
+        // Use the consumer as needed
+    }
+}
+```
+
+Neste exemplo, a propriedade `auto.offset.reset` é configurada para `earliest`, `latest` ou `none`, dependendo do
+comportamento desejado.

--- a/kafka-basic/src/main/java/code/with/vanilson/consumidor/ConsumerDemoWithShutdown.java
+++ b/kafka-basic/src/main/java/code/with/vanilson/consumidor/ConsumerDemoWithShutdown.java
@@ -54,7 +54,7 @@ public class ConsumerDemoWithShutdown {
      *
      * @param consumers - consumidor Kafka.
      */
-    static void pollMessages(KafkaConsumer<String, String> consumers) {
+    public static void pollMessages(KafkaConsumer<String, String> consumers) {
         try {
             // Subscrever o consumidor Kafka ao tópico Kafka chamado "demo_java".
             consumers.subscribe(List.of("demo_java"));

--- a/kafka-consumer-opensearch/pom.xml
+++ b/kafka-consumer-opensearch/pom.xml
@@ -36,6 +36,17 @@
             <version>${slf4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+
         <!--Okhttp-->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -64,20 +75,11 @@
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
         </dependency>
+        <dependency>
+            <groupId>code.with.vanilson</groupId>
+            <artifactId>kafka-basic</artifactId>
+        </dependency>
     </dependencies>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>code.with.vanilson</groupId>
-                <artifactId>kafka-basic</artifactId>
-                <version>1.0-SNAPSHOT</version>
-                <scope>compile</scope>
-            </dependency>
-        </dependencies>
-
-    </dependencyManagement>
 
 
     <build>


### PR DESCRIPTION
- Implemented `serializeLogParams` method to ensure `log_params` field is serialized as a string.
- Updated `addRecordToBulkRequest` method to use the `serializeLogParams` method.
- Added JavaDoc comments for `addRecordToBulkRequest` and `serializeLogParams` methods.
- Ensured proper handling of `log_params` field to prevent `mapper_parsing_exception` in OpenSearch.